### PR TITLE
fix: z-index in top-nav file

### DIFF
--- a/apps/www/components/layout/top-nav.tsx
+++ b/apps/www/components/layout/top-nav.tsx
@@ -7,7 +7,7 @@ import { NavItem, siteConfig } from "@/app/config";
 
 export const TopNav = ({ navItems }: { navItems: NavItem[] }) => {
   return (
-    <nav className="sticky top-0 z-10 flex h-16 items-center gap-10 border-b bg-background/60 px-4 backdrop-blur-xl transition-all">
+    <nav className="sticky top-0 z-30 flex h-16 items-center gap-10 border-b bg-background/60 px-4 backdrop-blur-xl transition-all">
       <Link href="/" className="flex items-center space-x-2">
         <Icons.logo />
         <span className="inline-block font-urban text-xl font-bold">


### PR DESCRIPTION
## Description

When scrolling through the homepage on the Badget site, it's evident that certain elements overlap the navbar, resulting in a suboptimal user experience. This issue stems from a z-index problem within the navbar component. To enhance the appearance and functionality of the marketing page, I've addressed this issue by adjusting the z-index values in the top-nav file. The fix ensures that elements no longer obscure the navbar while scrolling, thereby improving the overall aesthetics and usability of the page.

<!--
Please do not leave this blank
This PR fixes the bug.
-->

## What type of PR is this? (check all applicable)
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!--
Please use this format to link to relevant issues: Fixes #123
-->

Fixes #237 


## Mobile & Desktop Screenshots/Recordings

<!-- Add screenshots or recordings here -->
![Screenshot 2024-04-27 140247](https://github.com/projectx-codehagen/Badget/assets/123819411/283c9d3c-6f76-4852-b930-d2fb9ce90267)
![Screenshot 2024-04-27 140358](https://github.com/projectx-codehagen/Badget/assets/123819411/0b8faf15-e60d-4dec-897e-80dffad84b16)


## Steps to QA

1. Go to the Badget site's homepage page.
2. Scroll down the page.
3. Verify that no elements overlap the navbar.
4. Test the behavior on different screen sizes (if applicable).
5. Check for any other visual or functional issues related to the navbar.
6. Ensure that the navbar remains responsive and functional across various devices and browsers.



## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
