### PR TITLE
Fix apostrophe encoding in OpenCardsSection

### DIFF
--- a/apps/www/components/open-page/OpenCardsSection.tsx
+++ b/apps/www/components/open-page/OpenCardsSection.tsx
@@ -43,7 +43,7 @@ export default function OpenCardSection({ githubData }) {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
-              Merged PR`&apos;`s
+              Merged PR&apos;s
             </CardTitle>
             <GitPullRequestIcon className="h-4 w-4 text-muted-foreground" />
           </CardHeader>


### PR DESCRIPTION
## Description

This PR fixes the HTML entity encoding issue for the apostrophe in the OpenCardsSection.

## What type of PR is this? (check all applicable)

- [ ] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Sorry for not creating an issue beforehand.

## Mobile & Desktop Screenshots/Recordings

![badget-2](https://github.com/projectx-codehagen/Badget/assets/101335214/839b2c77-7a66-4001-bf14-f807ae5f698b)
![badget-1](https://github.com/projectx-codehagen/Badget/assets/101335214/65b00e61-18a9-4a72-a16b-3685f9a58361)

## Steps to QA

1. `bun run dev`
2. Go to `localhost:3000/open`
3. Validate you see the apostrophe rendered properly without the backticks

## Added to documentation?

- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
No
## [optional] What gif best describes this PR or how it makes you feel?
![first-time-ever-jeff](https://github.com/projectx-codehagen/Badget/assets/101335214/efb9211b-9e10-48a3-af3e-1d89ef7b7cb9)
